### PR TITLE
Add missing AutoTokenizer import in vLLM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ This repository provides an overview of all resources for the paper ["s1: Simple
 Install the `vllm` library and run:
 ```python
 from vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+
 model = LLM(
     "simplescaling/s1-32B",
     tensor_parallel_size=2,


### PR DESCRIPTION
Add missing `AutoTokenizer` import statement in the vLLM example code.